### PR TITLE
Fix crash when accessing decision template library

### DIFF
--- a/app/src/main/java/com/example/decider/TemplateLibraryActivity.java
+++ b/app/src/main/java/com/example/decider/TemplateLibraryActivity.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class TemplateLibraryActivity extends AppCompatActivity {
     
     private RecyclerView recyclerViewTemplates;
-    private TextView textViewEmpty;
+    private View textViewEmpty;
     private Button buttonBack;
     private TemplateAdapter templateAdapter;
     private PollStorage storage;


### PR DESCRIPTION
Correct `textViewEmpty` type to `View` in `TemplateLibraryActivity` to prevent `ClassCastException` when opening the Decision Template Library.

---
<a href="https://cursor.com/background-agent?bcId=bc-1afb59ac-923f-40c3-b3e2-d75f54d58257">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1afb59ac-923f-40c3-b3e2-d75f54d58257">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

