### PR TITLE
Fix decision template library error

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -61,7 +61,7 @@
         style="@style/Widget.MaterialComponents.Button.TextButton"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Thư viện mẫu quyết định"
+        android:text="@string/template_library_title"
         android:textSize="16sp"
         android:padding="16dp"
         android:drawableStart="@drawable/ic_library_books_24"

--- a/app/src/main/res/layout/activity_template_library.xml
+++ b/app/src/main/res/layout/activity_template_library.xml
@@ -18,7 +18,7 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Thư viện mẫu quyết định"
+        android:text="@string/template_library_title"
         android:textAppearance="?attr/textAppearanceHeadlineSmall"
         android:layout_marginBottom="16dp"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Decider</string>
+    <string name="template_library_title">Thư viện mẫu quyết định</string>
 </resources>


### PR DESCRIPTION
Fix hardcoded string lint warning by moving "Thư viện mẫu quyết định" to `strings.xml`.

---
<a href="https://cursor.com/background-agent?bcId=bc-40451e1d-4fe0-4869-b8ec-7e5da5e91a32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-40451e1d-4fe0-4869-b8ec-7e5da5e91a32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

